### PR TITLE
Add align-self to Info component

### DIFF
--- a/src/packages/core/src/info/info.css
+++ b/src/packages/core/src/info/info.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
+  align-self: flex-start;
   width: 100%;
   border-radius: var(--S4);
 }


### PR DESCRIPTION
Set `align-self: flex-start;` to support nesting inside flex containers.

Example: https://codepen.io/apust/pen/LYZPegw?editors=1100