### PR TITLE
Change font from Inter to IBM Plex Sans

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="styles.min.css">
-<link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 
 <style>
   html {

--- a/src/common/variables.css
+++ b/src/common/variables.css
@@ -19,12 +19,12 @@
   --C12: 656px;
 
   /* Fonts */
-  --H1: normal normal 600 24px/28px "Inter", sans-serif;
-  --H2: normal normal 600 20px/24px "Inter", sans-serif;
-  --H3: normal normal 600 16px/20px "Inter", sans-serif;
-  --Subhead: normal normal 500 14px/20px "Inter", sans-serif;
-  --Body1: normal normal 400 14px/20px "Inter", sans-serif;
-  --Body2: normal normal 400 12px/16px "Inter", sans-serif;
+  --H1: normal normal 600 24px/28px "IBM Plex Sans", sans-serif;
+  --H2: normal normal 600 20px/24px "IBM Plex Sans", sans-serif;
+  --H3: normal normal 600 16px/20px "IBM Plex Sans", sans-serif;
+  --Subhead: normal normal 500 14px/20px "IBM Plex Sans", sans-serif;
+  --Body1: normal normal 400 14px/20px "IBM Plex Sans", sans-serif;
+  --Body2: normal normal 400 12px/16px "IBM Plex Sans", sans-serif;
 
   /* Colors - Neutral */
   --N0: #FFFFFF;


### PR DESCRIPTION
Explore changing default font from Inter to IBM Plex Sans. This was requested because of [known problems](https://type.today/ru/journal/neo#Inter) with Cyrillic glyphs in Inter.

To see how components look with Plex run `git checkout feat/ibm-plex && yarn dev` and go to `http://localhost:6006/`.