### PR TITLE
Fix broken CSS when using button classes on anchors

### DIFF
--- a/src/packages/core/src/button/button.css
+++ b/src/packages/core/src/button/button.css
@@ -1,4 +1,6 @@
 ._e_button {
+  display: inline-flex;
+  align-items: center;
   border-radius: var(--S4);
   cursor: pointer;
   height: var(--S40);

--- a/src/packages/core/src/button/button.html
+++ b/src/packages/core/src/button/button.html
@@ -1,23 +1,23 @@
 <p>
-  <button class="_e_button">Click Me</button>
+  <a class="_e_button">Click Me</a>
   <button class="_e_button _e_button_appearance_primary">Click Me</button>
   <button class="_e_button _e_button_appearance_danger">Click Me</button>
 </p>
 
 <p>
-  <button class="_e_button _e_button_size_small">Click Me</button>
+  <a class="_e_button _e_button_size_small">Click Me</a>
   <button class="_e_button _e_button_size_small _e_button_appearance_primary">Click Me</button>
   <button class="_e_button _e_button_size_small _e_button_appearance_danger">Click Me</button>
 </p>
 
 <p>
-  <button class="_e_button _e_button_size_large">Click Me</button>
+  <a class="_e_button _e_button_size_large">Click Me</a>
   <button class="_e_button _e_button_size_large _e_button_appearance_primary">Click Me</button>
   <button class="_e_button _e_button_size_large _e_button_appearance_danger">Click Me</button>
 </p>
 
 <p>
-  <button disabled class="_e_button _e_button_disabled">Click Me</button>
+  <a disabled class="_e_button _e_button_disabled">Click Me</a>
   <button disabled class="_e_button _e_button_disabled _e_button_appearance_primary">Click Me</button>
   <button disabled class="_e_button _e_button_disabled _e_button_appearance_danger">Click Me</button>
 </p>


### PR DESCRIPTION
Using button class as following

```HTML
<a class="_e_button">Click Me</a>
```

would yield a broken result.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/2337671/96876967-441e6700-14a3-11eb-84d7-38ca12e66bd0.png">
