### PR TITLE
Move Snackbar countdown inside button

### DIFF
--- a/src/packages/core/src/snackbar/snackbar.css
+++ b/src/packages/core/src/snackbar/snackbar.css
@@ -31,6 +31,7 @@
 ._e_snackbar__button._e_button {
   background-color: var(--N600);
   color: var(--N0);
+  font-feature-settings: "tnum";
 
   &:hover {
     background-color: var(--N700);

--- a/src/packages/core/src/snackbar/snackbar.html
+++ b/src/packages/core/src/snackbar/snackbar.html
@@ -1,7 +1,6 @@
 <div class="_e_snackbar">
   <div class="_e_snackbar__text">
-    Action completed...
-    <span class="_e_snackbar__timer">:10</span>
+    Action completed.
   </div>
-  <button class="_e_button _e_snackbar__button">Отменить</button>
+  <button class="_e_button _e_snackbar__button">Отменить :09</button>
 </div>


### PR DESCRIPTION
This changes recommended position for Snackbar countdown.

<img width="713" alt="image" src="https://user-images.githubusercontent.com/2337671/97546017-6b72b800-19fe-11eb-80fe-dae2969841fc.png">

**Note:** this is not a breaking change, `._e_snackbar__timer` class is still available.