### PR TITLE
Publish non-minified CSS

### DIFF
--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -15,8 +15,9 @@
   },
   "scripts": {
     "prepare-dist": "mkdir -p dist && cp package.json dist && cp ../../../LICENSE.md dist",
-    "postcss": "mkdir -p dist && find src ../../common -name '*.css' | xargs cat | postcss > dist/styles.min.css",
-    "prepublishOnly": "yarn prepare-dist && yarn postcss"
+    "postcss": "mkdir -p dist && find src ../../common -name '*.css' | xargs cat | postcss > dist/styles.css",
+    "postcss:minify": "mkdir -p dist && find src ../../common -name '*.css' | xargs cat | postcss --env=minify > dist/styles.min.css",
+    "prepublishOnly": "yarn prepare-dist && yarn postcss && yarn postcss:minify"
   },
   "publishConfig": {
     "access": "public"

--- a/src/packages/layout/package.json
+++ b/src/packages/layout/package.json
@@ -18,8 +18,9 @@
   },
   "scripts": {
     "prepare-dist": "mkdir -p dist && cp package.json dist && cp ../../../LICENSE.md dist",
-    "postcss": "mkdir -p dist && find src ../../common -name '*.css' | xargs cat | postcss > dist/styles.min.css",
-    "prepublishOnly": "yarn prepare-dist && yarn postcss"
+    "postcss": "mkdir -p dist && find src ../../common -name '*.css' | xargs cat | postcss > dist/styles.css",
+    "postcss:minify": "mkdir -p dist && find src ../../common -name '*.css' | xargs cat | postcss --env=minify > dist/styles.min.css",
+    "prepublishOnly": "yarn prepare-dist && yarn postcss && yarn postcss:minify"
   },
   "publishConfig": {
     "access": "public"

--- a/src/packages/postcss.config.js
+++ b/src/packages/postcss.config.js
@@ -1,6 +1,6 @@
 let reset = require('../common/reset.js');
 
-module.exports = () => ({
+module.exports = (ctx) => ({
   plugins: {
     'postcss-nesting': {},
     'postcss-autoreset': {
@@ -14,6 +14,6 @@ module.exports = () => ({
     'postcss-custom-properties': {
       importFrom: '../../common/variables.css',
     },
-    cssnano: {},
+    cssnano: ctx.env === 'minify' ? {} : false,
   },
 });


### PR DESCRIPTION
Some build workflows (i.e. `react-scripts build`) fail with imported `styles.min.css`. This should be investigated further. But since these workflows do minification on their own, we can supply them with non-minified version of Elephas CSS.