### PR TITLE
Change legend tag to div

### DIFF
--- a/src/packages/core/src/fieldset/fieldset-checkbox.html
+++ b/src/packages/core/src/fieldset/fieldset-checkbox.html
@@ -1,5 +1,5 @@
 <fieldset class="_e_fieldset">
-  <legend class="_e_fieldset__legend">Mind picking any fruits you like?</legend>
+  <div class="_e_fieldset__legend">Mind picking any fruits you like?</div>
   <label class="_e_checkbox">
     <input class="_e_checkbox__input" type="checkbox" name="fruits" />
     <span class="_e_checkbox__icon"></span>

--- a/src/packages/core/src/fieldset/fieldset-radio.html
+++ b/src/packages/core/src/fieldset/fieldset-radio.html
@@ -1,5 +1,5 @@
 <fieldset class="_e_fieldset">
-  <legend class="_e_fieldset__legend">What do you stand for?</legend>
+  <div class="_e_fieldset__legend">What do you stand for?</div>
   <label class="_e_radio">
     <input class="_e_radio__input" type="radio" name="options" checked />
     <span class="_e_radio__icon"></span>

--- a/src/packages/core/src/fieldset/fieldset-required.html
+++ b/src/packages/core/src/fieldset/fieldset-required.html
@@ -1,5 +1,5 @@
 <fieldset class="_e_fieldset">
-  <legend class="_e_fieldset__legend">What do you stand for?</legend>
+  <div class="_e_fieldset__legend">What do you stand for?</div>
   <label class="_e_radio">
     <input class="_e_radio__input" type="radio" name="options2" required />
     <span class="_e_radio__icon"></span>
@@ -14,7 +14,7 @@
 </fieldset>
 
 <fieldset class="_e_fieldset" style="margin-top: 24px;">
-  <legend class="_e_fieldset__legend">Mind picking any fruits you like?</legend>
+  <div class="_e_fieldset__legend">Mind picking any fruits you like?</div>
   <label class="_e_checkbox">
     <input class="_e_checkbox__input" type="checkbox" name="fruits2" required />
     <span class="_e_checkbox__icon"></span>

--- a/src/packages/layout/src/form/form.html
+++ b/src/packages/layout/src/form/form.html
@@ -26,7 +26,7 @@
     </div>
   </section>
   <fieldset class="_e_form__fieldset _e_fieldset">
-    <legend class="_e_fieldset__legend">Gender</legend>
+    <div class="_e_fieldset__legend">Gender</div>
     <label class="_e_radio">
       <input class="_e_radio__input" type="radio" name="options" />
       <span class="_e_radio__icon"></span>


### PR DESCRIPTION
In the latest update (https://github.com/cft-group/elephas/commit/70024f5a311845502e331ed5a7ec581a0048e1ac) I changed fieldset's `display` property to `grid`.

For unknown reason, using `<legend>` inside `<fieldset>` with `display: grid;` breaks the layout in Chrome. It adds a large padding between legend and inputs.

<img width="267" alt="image" src="https://user-images.githubusercontent.com/2337671/100990149-29e8a600-3584-11eb-9d18-52cb61eb4af8.png">

Since I did not found any way to fix this with CSS, the only reasonable solution is to use `<div>` instead of `<legend>`. 
