### PR TITLE
Change fieldset display to flex

### DIFF
--- a/src/packages/core/src/checkbox/checkbox.css
+++ b/src/packages/core/src/checkbox/checkbox.css
@@ -12,13 +12,6 @@
   }
 }
 
-/* IE11 only */
-@media screen and (-ms-high-contrast: none) {
-  ._e_checkbox {
-    display: flex;
-  }
-}
-
 ._e_checkbox_disabled {
   cursor: default;
   pointer-events: none;

--- a/src/packages/core/src/fieldset/fieldset.css
+++ b/src/packages/core/src/fieldset/fieldset.css
@@ -1,20 +1,14 @@
 ._e_fieldset {
-  display: grid;
-  justify-items: start;
-  
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
   & > ._e_checkbox, > ._e_radio {
     margin-bottom: var(--S12);
 
     &:last-child {
       margin-bottom: 0;
     }
-  }
-}
-
-/* IE11 only */
-@media screen and (-ms-high-contrast: none) {
-  ._e_fieldset {
-    display: block;
   }
 }
 

--- a/src/packages/core/src/radio/radio.css
+++ b/src/packages/core/src/radio/radio.css
@@ -12,13 +12,6 @@
   }
 }
 
-/* IE11 only */
-@media screen and (-ms-high-contrast: none) {
-  ._e_radio {
-    display: flex;
-  }
-}
-
 ._e_radio_disabled {
   cursor: default;
   pointer-events: none;


### PR DESCRIPTION
The bug described in https://github.com/cft-group/elephas/pull/79 can be fixed by changing `display: grid;` to `display: flex;`. Since IE11 is fine with flex layouts, we can also remove IE11 hacks.