### PR TITLE
Add extra font styles

### DIFF
--- a/src/common/variables.css
+++ b/src/common/variables.css
@@ -25,6 +25,9 @@
   --Subhead: normal normal 500 14px/20px "Inter", sans-serif;
   --Body1: normal normal 400 14px/20px "Inter", sans-serif;
   --Body2: normal normal 400 12px/16px "Inter", sans-serif;
+  --Body2Medium: normal normal 500 12px/16px "Inter", sans-serif;
+  --Footnote: normal normal 500 10px/14px "Inter", sans-serif;
+  --Tnum: "tnum" 1;
 
   /* Colors - Neutral */
   --N0: #FFFFFF;


### PR DESCRIPTION
Unfortunately, we can't use a single line of CSS to set both font size/weight and tabular numbers feature.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font):

> If font is specified as a shorthand for several font-related properties, then:
> [...]
> `font-variant` may only specify the values defined in CSS 2.1, that is `normal` and `small-caps`

This means we will have to use two lines to set styles such as `Body1Tnum`:

```CSS
p {
  font: var(--Body1);
  font-feature-settings: var(--Tnum);
}
```

Closes #103.